### PR TITLE
Update README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -27,10 +27,7 @@ Ant-based tools and scripts to automate build processes.
 
 ### PDE Doc 
 
-Help documentation for PDE, which is colocated with the other project documentation here:
-
-https://github.com/eclipse-platform/eclipse.platform.common/tree/master/bundles/org.eclipse.pde.doc.user
-
+Help documentation for PDE, which is [stored together with other project documentation](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/tree/master/eclipse.platform.common/bundles/org.eclipse.pde.doc.user) in the platform aggregator.
 
 ## Reporting issues
 


### PR DESCRIPTION
Fix broken link after repository reorganization.

Someone with more insights might want to check why there are 2 almost identical readmes. This one in `.github` and again in `.github/profile`. Maybe those can be merged?